### PR TITLE
orElse(function) would always return it's value even if type was matched

### DIFF
--- a/src/main/java/com/blogspot/nurkiewicz/typeof/TerminalThenReturn.java
+++ b/src/main/java/com/blogspot/nurkiewicz/typeof/TerminalThenReturn.java
@@ -1,5 +1,7 @@
 package com.blogspot.nurkiewicz.typeof;
 
+import java.util.function.Function;
+
 /**
  * @author Tomasz Nurkiewicz
  * @since 21.09.13, 22:22
@@ -15,16 +17,21 @@ class TerminalThenReturn<S, R> extends ThenReturn<S, R> {
 
 	@Override
 	public <T> ReturnIs<S, T, R> is(Class<T> expectedType) {
-		return new TerminalReturnIs<>(object, result);
+		return new TerminalReturnIs<>(object, this.result);
 	}
 
 	@Override
 	public R get() {
-		return result;
+		return this.result;
 	}
 
 	@Override
 	public R orElse(R result) {
 		return this.result;
+	}
+	
+	@Override
+	public R orElse(Function<S, R> resultFun) {
+	    return this.result;
 	}
 }

--- a/src/test/java/com/blogspot/nurkiewicz/typeof/tests/IsThenReturnTest.java
+++ b/src/test/java/com/blogspot/nurkiewicz/typeof/tests/IsThenReturnTest.java
@@ -167,4 +167,16 @@ public class IsThenReturnTest {
 		//then
 		assertThat(result).isEqualTo(17);
 	}
+	
+    @Test
+    public void shouldNotReturnOrElseValueWhenSuccessful() {
+        // when
+        final Integer result = whenTypeOf("100").
+                is(String.class).thenReturn(Integer::valueOf).
+                is(Date.class).thenReturn(d -> (int) d.getTime()).
+                is(Float.class).thenReturn(Float::intValue).
+                orElse(x -> 12345);
+        
+        assertThat(result).isEqualTo(100);
+    }
 }


### PR DESCRIPTION
Hi, found this when wanting to return a default function.
